### PR TITLE
788 - Configuration + template changes for SMS 2FA flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>dasniko</groupId>

--- a/src/main/java/dasniko/keycloak/authenticator/InvalidMobileNumberException.java
+++ b/src/main/java/dasniko/keycloak/authenticator/InvalidMobileNumberException.java
@@ -1,6 +1,6 @@
 package dasniko.keycloak.authenticator;
 
-public class InvalidMobileNumberException extends Exception  {
+public class InvalidMobileNumberException extends Exception {
 
 	public InvalidMobileNumberException(String message) {
 		super(message);

--- a/src/main/java/dasniko/keycloak/authenticator/OTPAuthenticator.java
+++ b/src/main/java/dasniko/keycloak/authenticator/OTPAuthenticator.java
@@ -14,12 +14,13 @@ public abstract class OTPAuthenticator implements Authenticator {
 
 	protected String getSecretCode(AuthenticatorConfigModel config) {
 		int length = Integer.parseInt(config.getConfig().get(CODE_LENGTH));
-        return SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
+		return SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
 	}
 
 	/**
-	 * Retrieves the OTP time-to-live value from the configuration in the Keycloak Admin UI
+	 * Retrieves the OTP time-to-live value from the configuration in the Keycloak Admin UI.
 	 * Value is in seconds
+	 *
 	 * @param config AuthenticatorConfigModel
 	 * @return Integer
 	 */
@@ -31,7 +32,8 @@ public abstract class OTPAuthenticator implements Authenticator {
 	 * Validates that auth session context has required defined values
 	 * Will throw an error if code or ttl values are not defined
 	 * An error page will be displayed in the UI
-	 * @param  context  AuthenticationFlowContext
+	 *
+	 * @param context AuthenticationFlowContext
 	 */
 	protected void codeContextIsValid(AuthenticationFlowContext context) {
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
@@ -45,7 +47,8 @@ public abstract class OTPAuthenticator implements Authenticator {
 
 	/**
 	 * Checks that the OTP code entered by a user matches the code in the auth session context
-	 * @param  context  AuthenticationFlowContext
+	 *
+	 * @param context AuthenticationFlowContext
 	 * @return boolean
 	 */
 	private boolean enteredCodeIsValid(AuthenticationFlowContext context) {
@@ -59,9 +62,10 @@ public abstract class OTPAuthenticator implements Authenticator {
 	 * Validates that the OTP code entered by a user is correct, and still valid for use in the current session.
 	 * On success, OTP flow is complete.
 	 * If either check fails, will set an error in the context form, and display an error screen in the UI indicating the type of error.
-	 * @param  context  AuthenticationFlowContext
+	 *
+	 * @param context  AuthenticationFlowContext
 	 * @param formCode String
-     */
+	 */
 	protected void validateEnteredCode(AuthenticationFlowContext context, String formCode) {
 		// TODO: can/should we add a maximum number of attempts before cancelling the session/throwing an error?
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
@@ -89,6 +93,7 @@ public abstract class OTPAuthenticator implements Authenticator {
 			}
 		}
 	}
+
 	@Override
 	public boolean requiresUser() {
 		return true;

--- a/src/main/java/dasniko/keycloak/authenticator/OTPAuthenticator.java
+++ b/src/main/java/dasniko/keycloak/authenticator/OTPAuthenticator.java
@@ -17,6 +17,12 @@ public abstract class OTPAuthenticator implements Authenticator {
         return SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
 	}
 
+	/**
+	 * Retrieves the OTP time-to-live value from the configuration in the Keycloak Admin UI
+	 * Value is in seconds
+	 * @param config AuthenticatorConfigModel
+	 * @return Integer
+	 */
 	protected Integer getTTL(AuthenticatorConfigModel config) {
 		return Integer.parseInt(config.getConfig().get(CODE_TTL));
 	}

--- a/src/main/java/dasniko/keycloak/authenticator/OTPConstants.java
+++ b/src/main/java/dasniko/keycloak/authenticator/OTPConstants.java
@@ -7,7 +7,8 @@ public class OTPConstants {
 	public String CODE = "code";
 	public String CODE_LENGTH = "length";
 	public String CODE_TTL = "ttl";
-	public String SENDER_ID = "senderId";
 	public String SIMULATION_MODE = "simulation";
 	public String MOBILE_NUMBER_FIELD = "mobilePhoneNumber";
+	public String ORIGINATION_NUMBER = "originationNumber";
+
 }

--- a/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticator.java
+++ b/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticator.java
@@ -41,19 +41,20 @@ public class SmsAuthenticator extends OTPAuthenticator {
 			Locale locale = session.getContext().resolveLocale(user);
 
 			// throws error if invalid format
-			if (mobileNumber == null || !isValidPhoneNumber(mobileNumber)) {
+			if (!isValidPhoneNumber(mobileNumber)) {
 				String errMessage = theme.getMessages(locale).getProperty("invalidMobileNumber");
 				throw new InvalidMobileNumberException(errMessage);
 			}
-			int ttl = getTTL(config);
+			// OTP code in seconds
+			int ttlInSeconds = getTTL(config);
 			String code = getSecretCode(config);
 
 			AuthenticationSessionModel authSession = context.getAuthenticationSession();
 			authSession.setAuthNote(CODE, code);
-			authSession.setAuthNote(CODE_TTL, Long.toString(System.currentTimeMillis() + (ttl * 1000L)));
+			authSession.setAuthNote(CODE_TTL, Long.toString(System.currentTimeMillis() + (ttlInSeconds * 1000L)));
 
 			String smsAuthText = theme.getMessages(locale).getProperty("authCodeText");
-			Integer formattedTtl = Math.floorDiv(ttl, 60);
+			Integer formattedTtl = Math.floorDiv(ttlInSeconds, 60);
 			String smsText = String.format(smsAuthText, code);
 			String formattedMobileNumber = mobileNumber.replaceFirst(PHONE_NUMBER_FORMAT, "$1-$2-$3");
 
@@ -94,8 +95,11 @@ public class SmsAuthenticator extends OTPAuthenticator {
 	}
 
 	private boolean isValidPhoneNumber(String phoneNumber) {
+		if (phoneNumber == null) {
+			return false;
+		}
 		Matcher validPhoneNumber = REGEX_PHONE_NUMBER.matcher(phoneNumber);
-		return validPhoneNumber.find();
+		return validPhoneNumber.matches();
 	}
 
 }

--- a/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticator.java
+++ b/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticator.java
@@ -45,7 +45,7 @@ public class SmsAuthenticator extends OTPAuthenticator {
 				String errMessage = theme.getMessages(locale).getProperty("invalidMobileNumber");
 				throw new InvalidMobileNumberException(errMessage);
 			}
-			// OTP code in seconds
+
 			int ttlInSeconds = getTTL(config);
 			String code = getSecretCode(config);
 

--- a/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticator.java
+++ b/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticator.java
@@ -52,7 +52,6 @@ public class SmsAuthenticator extends OTPAuthenticator {
 			String smsAuthText = theme.getMessages(locale).getProperty("authCodeText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			// TODO: may need to append country code
 			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
 
 			context.challenge(context.form().setAttribute("realm", context.getRealm()).createForm(TPL_CODE));
@@ -62,9 +61,10 @@ public class SmsAuthenticator extends OTPAuthenticator {
 					context.form().setError("smsAuthSmsNotSent", e.getMessage())
 						.createErrorPage(Response.Status.BAD_REQUEST));
 			} else {
-				context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
-					context.form().setError("smsAuthSmsNotSent", e.getMessage())
-						.createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+				// display error screen with general error message
+					context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+						context.form().setError("smsAuthSmsNotSent", "There was an error attempting to send SMS message.")
+							.createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
 			}
 		}
 

--- a/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticatorFactory.java
+++ b/src/main/java/dasniko/keycloak/authenticator/SmsAuthenticatorFactory.java
@@ -63,8 +63,8 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 		return List.of(
 			new ProviderConfigProperty(CODE_LENGTH, "Code length", "The number of digits of the generated code.", ProviderConfigProperty.STRING_TYPE, 6),
 			new ProviderConfigProperty(CODE_TTL, "Time-to-live", "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE, "300"),
-			new ProviderConfigProperty(SENDER_ID, "SenderId", "The sender ID is displayed as the message sender on the receiving device.", ProviderConfigProperty.STRING_TYPE, "Keycloak"),
-			new ProviderConfigProperty(SIMULATION_MODE, "Simulation mode", "In simulation mode, the SMS won't be sent, but printed to the server logs", ProviderConfigProperty.BOOLEAN_TYPE, true)
+			new ProviderConfigProperty(SIMULATION_MODE, "Simulation mode", "In simulation mode, the SMS won't be sent, but printed to the server logs", ProviderConfigProperty.BOOLEAN_TYPE, true),
+			new ProviderConfigProperty(ORIGINATION_NUMBER, "Origination number", "The origination phone number configured for the SMS Provider, this is displayed as the message sender on the receiving device", ProviderConfigProperty.STRING_TYPE, "")
 		);
 	}
 

--- a/src/main/java/dasniko/keycloak/authenticator/gateway/AwsSmsService.java
+++ b/src/main/java/dasniko/keycloak/authenticator/gateway/AwsSmsService.java
@@ -3,7 +3,9 @@ package dasniko.keycloak.authenticator.gateway;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.awssdk.services.sns.model.*;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/dasniko/keycloak/authenticator/gateway/AwsSmsService.java
+++ b/src/main/java/dasniko/keycloak/authenticator/gateway/AwsSmsService.java
@@ -1,7 +1,9 @@
 package dasniko.keycloak.authenticator.gateway;
 
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,28 +11,42 @@ import java.util.Map;
 /**
  * @author Niko Köbler, https://www.n-k.de, @dasniko
  */
+@Slf4j
 public class AwsSmsService implements SmsService {
 
-	private static final SnsClient sns = SnsClient.create();
-
-	private final String senderId;
+	private static final SnsClient sns = SnsClient.builder().build();
+	private final String originationNumber;
+	private static final String smsType = "Transactional";
+	private static final String countryCode = "+1";
 
 	AwsSmsService(Map<String, String> config) {
-		senderId = config.get("senderId");
+		// the config arg here is the config provided from the Keycloak Browser Flow form, when you set up the authentication extension
+		originationNumber = config.get("originationNumber");
 	}
 
 	@Override
-	public void send(String phoneNumber, String message) {
+	public void send(String phoneNumber, String message) throws AwsServiceException {
 		Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
-		messageAttributes.put("AWS.SNS.SMS.SenderID",
-			MessageAttributeValue.builder().stringValue(senderId).dataType("String").build());
 		messageAttributes.put("AWS.SNS.SMS.SMSType",
-			MessageAttributeValue.builder().stringValue("Transactional").dataType("String").build());
+			MessageAttributeValue.builder().stringValue(smsType).dataType("String").build());
+		messageAttributes.put("AWS.MM.SMS.OriginationNumber", MessageAttributeValue.builder().stringValue(originationNumber).dataType("String").build());
 
-		sns.publish(builder -> builder
-			.message(message)
-			.phoneNumber(phoneNumber)
-			.messageAttributes(messageAttributes));
+		try {
+			String numberWithCountryCode = countryCode + phoneNumber;
+
+			PublishRequest request = PublishRequest.builder()
+				.message(message)
+				.phoneNumber(numberWithCountryCode)
+				.messageAttributes(messageAttributes)
+				.build();
+
+			PublishResponse response = sns.publish(request);
+			log.debug(response.messageId() + " - Message successfully sent, with response status: " + response.sdkHttpResponse().statusCode());
+		} catch (AwsServiceException e) {
+			log.error("Error from AWS SNS service - " + e.getMessage());
+			throw e;
+		}
+
 	}
 
 }

--- a/src/main/java/dasniko/keycloak/authenticator/gateway/SmsService.java
+++ b/src/main/java/dasniko/keycloak/authenticator/gateway/SmsService.java
@@ -1,7 +1,5 @@
 package dasniko.keycloak.authenticator.gateway;
 
-import java.util.Map;
-
 /**
  * @author Niko Köbler, https://www.n-k.de, @dasniko
  */

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,10 +1,9 @@
-authCodeText=Your one-time code is %1$s and is valid for %2$d minutes.
+authCodeText=%1$s is your one time passcode from OHCRN. %1$s est votre code d'accès à usage unique de l'OHCRN.
 
-smsAuthTitle=SMS Code
-smsAuthCodeTitle=SMS Code
-smsAuthLabel=Code
-smsAuthInstruction=Enter the code we sent to your device.
-
+smsAuthTitle=2-Step Verification
+smsAuthLabel=Enter your verification code:
+smsAuthInstruction1=A verification code has been sent to your mobile number <strong>{0}</strong>.
+smsAuthInstruction2=This code will be valid for {0} minutes.
 smsAuthSmsNotSent=The SMS could not be sent, because {0}.
 invalidMobileNumber=an invalid mobile phone number was provided
 
@@ -17,8 +16,5 @@ emailAuthLabel=Code
 emailAuthInstruction=Enter the code we sent to your email.
 emailAuthSubject=One-time passcode
 
-sms-authenticator-display-name=SMS OTP Authentication
-sms-authenticator-help-text=Enter an OTP sent via SMS to your mobile phone.
-
-email-authenticator-display-name=Email OTP Authentication
-email-authenticator-help-text=Enter an OTP sent via email.
+doVerifyCode=Verify
+resendCode=Didn't receive a code? Try again.

--- a/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -1,10 +1,9 @@
-authCodeText=Votre code à usage unique est %1$s et est valable pour %2$d minutes.
+authCodeText=%1$s is your one time passcode from OHCRN. %1$s est votre code d'accès à usage unique de l'OHCRN.
 
-smsAuthTitle=Code SMS
-smsAuthCodeTitle=SMS Code
-smsAuthLabel=Code
-smsAuthInstruction=Entrez le code que nous avons envoyé à votre appareil.
-
+smsAuthTitle=Vérification en 2 étapes
+smsAuthLabel=Entrez votre code de vérification:
+smsAuthInstruction1=Un code de vérification a été envoyé à votre numéro de mobile <strong>{0}</strong>.
+smsAuthInstruction2=Ce code sera valide pendant {0} minutes.
 smsAuthSmsNotSent=Le SMS n''a pas pu être envoyé, car {0}.
 invalidMobileNumber=un numéro de téléphone mobile non valide a été fourni
 
@@ -15,10 +14,7 @@ emailAuthTitle=Code de courrier électronique
 emailAuthCodeTitle=Code de courrier électronique
 emailAuthLabel=Code
 emailAuthInstruction=Entrez le code que nous avons envoyé à votre email.
-emailAuthSubject=Code d'accès à usage unique
+emailAuthSubject=Code d''accès à usage unique
 
-sms-authenticator-display-name=SMS OTP Authentication
-sms-authenticator-help-text=Enter an OTP sent via SMS to your mobile phone.
-
-email-authenticator-display-name=Email OTP Authentication
-email-authenticator-help-text=Enter an OTP sent via email
+doVerifyCode=Vérifier
+resendCode=Vous n''avez pas reçu de code? Essayer à nouveau.

--- a/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -1,6 +1,6 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true displayRequiredFields=false; section>
-	<#if section = "info">
+<@layout.registrationLayout displayInfo=false displayRequiredFields=false; section>
+	<#if section = "sms-info">
 		<h2 id="sms-title">${msg("smsAuthTitle")}</h2>
 		<div class="sms-instructions">
 			${msg("smsAuthInstruction1", mobileNumber)?no_esc}

--- a/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -1,9 +1,11 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true; section>
-	<#if section = "header">
-		${msg("smsAuthTitle",realm.displayName)}
-	<#elseif section = "show-username">
-		<h1>${msg("smsAuthCodeTitle", realm.displayName)}</h1>
+<@layout.registrationLayout displayInfo=true displayRequiredFields=false; section>
+	<#if section = "info">
+		<h2 id="sms-title">${msg("smsAuthTitle")}</h2>
+		<div class="sms-instructions">
+			${msg("smsAuthInstruction1", mobileNumber)?no_esc}
+			${msg("smsAuthInstruction2", codeTtl)}
+		</div>
 	<#elseif section = "form">
 		<form id="kc-sms-code-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
 			<div class="${properties.kcFormGroupClass!}">
@@ -16,11 +18,13 @@
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
 				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-					<input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+					<input
+						class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+						type="submit" value="${msg("doVerifyCode")}"/>
 				</div>
 			</div>
 		</form>
-	<#elseif section = "info" >
-		${msg("smsAuthInstruction")}
+	<#elseif section = "resend">
+		<div id="retry-wrapper" class="${properties.kcFormButtonsClass!}"><a class="retry-code" href="">${msg("resendCode")}</a></div>
 	</#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
Work for [#788](https://github.com/OHCRN/platform/issues/788)

Adds configuration setup to connect to AWS messaging services.

## Authenticator
- adds required message attributes for AWS SNS publish():
    - `originationNumber` - the number that text messages are sent from. This will be configurable from the Keycloak Admin UI form
    - `smsType` - the type of sms message being sent. `Transactional` is set because it is the correct type for the OTP messages we are sending
 - Sets a country code as `"+1"`; we are only sending messages within Canada. This is appended to the incoming phone number from the Keycloak user. Allowed destination countries can be controlled in our AWS account config
 - other SNS Client configuration values will be inferred from our environment variables (credentials + region)
- removes `SenderId` config value as it is not valid in Canada
- adds formatting for phone number displayed on sms code entry screen
- changes server error message to generic text to prevent aws stack trace from being shown

## Messages
- adds verbiage to match form mocks + text message that is sent
- text message is provided in both en + fr as we're not yet supporting user's preferred language

## Form template
- updates layout to match Figma mock
- PR to support this layout change is [here](https://github.com/OHCRN/keycloak-theme/pull/4). Themes are stored in a separate directory (`/themes`) from the Authentication flow extension (`/providers`)