### PR TITLE
Remove french text from sms message, bump pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>dasniko</groupId>
 	<artifactId>keycloak-2fa-sms-authenticator</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,4 +1,4 @@
-authCodeText=%1$s is your one time passcode from OHCRN. %1$s est votre code d'accès à usage unique de l'OHCRN.
+authCodeText=%1$s is your one time passcode from OHCRN.
 
 smsAuthTitle=2-Step Verification
 smsAuthLabel=Enter your verification code:


### PR DESCRIPTION
Only removes the French text from the `en` messages file. French urls will be disabled from the Consent UI so `fr` messages will not be accessible in Keycloak login flows.